### PR TITLE
Django migrations fix

### DIFF
--- a/django_encrypted_json/fields.py
+++ b/django_encrypted_json/fields.py
@@ -52,6 +52,11 @@ class EncryptedValueJsonField(JsonField):
 
         return super(EncryptedValueJsonField, self).__init__(*args, **kwargs)
 
+    def desconstruct(self):
+        name, path, args, kwargs = super(EncryptedValueJsonField, self).deconstruct()
+        del kwargs["skip_keys"]
+        return name, path, args, kwargs
+
     def to_python(self, value):
         value = super(EncryptedValueJsonField, self).to_python(value)
         return decrypt_values(value)

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ Encrypted PostgreSQL json field support for Django.
 
 setup(
     name="django-encrypted-pgjson",
-    version="0.1.1",
-    url="https://github.com/",
+    version="0.2.0",
+    url="https://github.com/LucasRoesler/django-encrypted-json",
     license="MIT",
     platforms=["OS Independent"],
     description=description.strip(),
@@ -27,7 +27,7 @@ setup(
     ],
     zip_safe=False,
     classifiers=[
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 5 - Production/Stable",
         "Framework :: Django",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
#### What

Add a deconstruct method to correctly address the requirements for the Django migrations system.
#### Why

Migrations were incorrectly being created even though the model was not actually changed.
#### How

Removed the `skip_keys` from the deconstruct output so that it was not detected as a change. 
