### PR TITLE
Return valid JSON when blank=True

### DIFF
--- a/django_encrypted_json/fields.py
+++ b/django_encrypted_json/fields.py
@@ -1,3 +1,4 @@
+from django.db.models.fields import NOT_PROVIDED
 from django_pgjson.fields import JsonField, JsonBField, JsonAdapter
 
 from .utils import decrypt_values, encrypt_values
@@ -65,6 +66,18 @@ class EncryptedValueJsonField(JsonField):
         value = super(JsonField, self).get_db_prep_value(
             value, connection, prepared=prepared
         )
+
+        # Because an empty string is not valid json, replace it with an empty
+        # dict
+        if self.blank and value == "":
+            if self.default != NOT_PROVIDED:
+                if callable(self.default):
+                    value = self.default()
+                else:
+                    value = self.default
+            else:
+                value = {}
+
         if self.null and value is None:
             return None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptography==1.0.1
+cryptography==1.4
 Django==1.8.4
 django-pgjson==0.3.1
 psycopg2==2.6.1

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ Encrypted PostgreSQL json field support for Django.
 
 setup(
     name="django-encrypted-pgjson",
-    version="0.2.2",
+    version="0.2.3",
     url="https://github.com/LucasRoesler/django-encrypted-json",
     license="MIT",
     platforms=["OS Independent"],

--- a/tests/test_app/migrations/0003_testmodel_partial_encrypt_w_default.py
+++ b/tests/test_app/migrations/0003_testmodel_partial_encrypt_w_default.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django_encrypted_json.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('test_app', '0002_testmodel_partial_encrypt'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='testmodel',
+            name='partial_encrypt_w_default',
+            field=django_encrypted_json.fields.EncryptedValueJsonField(default=[], blank=True),
+        ),
+    ]

--- a/tests/test_app/models.py
+++ b/tests/test_app/models.py
@@ -10,3 +10,5 @@ class TestModel(models.Model):
     optional_json = EncryptedValueJsonField(blank=True, null=True)
     partial_encrypt = EncryptedValueJsonField(
         blank=True, null=True, skip_keys=('test', ))
+    partial_encrypt_w_default = EncryptedValueJsonField(
+        blank=True, skip_keys=('test', ), default=[])

--- a/tests/test_app/tests.py
+++ b/tests/test_app/tests.py
@@ -26,6 +26,26 @@ UNICODE_HODGEPODGE = \
 class PlainJsonField(TestCase):
     maxDiff = 2000
 
+    def test_blank_field(self):
+        # an empty string isn't valid json. make sure that empty string is
+        # translated to an empty dict
+        instance = TestModel.objects.create()
+        instance.partial_encrypt = ""
+        instance.save()
+
+        d = TestModel.objects.get(pk=instance.pk).partial_encrypt
+        self.assertEqual(d, {})
+
+    def test_blank_field_with_default(self):
+        # an empty string isn't valid json. make sure that empty string is
+        # translated to an empty dict
+        instance = TestModel.objects.create()
+        instance.partial_encrypt_w_default = ""
+        instance.save()
+
+        d = TestModel.objects.get(pk=instance.pk).partial_encrypt_w_default
+        self.assertEqual(d, list())
+
     def test_default_create(self):
         instance = TestModel.objects.create()
 

--- a/tests/tests_project/settings.py
+++ b/tests/tests_project/settings.py
@@ -33,7 +33,6 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
-
 # Application definition
 
 INSTALLED_APPS = (


### PR DESCRIPTION
If a user enters nothing in the django admin when blank=True, an empty string is saved to the database. This causes apps to fail because they are expecting a valid json object. This fix converts `""` to `{}` so apps don't have to check for the empty string case.
